### PR TITLE
Change link selector to fix underline

### DIFF
--- a/_sass/_links.scss
+++ b/_sass/_links.scss
@@ -3,7 +3,7 @@ a {
   background-image: linear-gradient(to top,
     rgba(0,0,0,0) 13%,
     rgba($link-color,.8) 13%,
-    rgba($link-color,.8) 17%,
+    rgba($link-color,.8) 18%,
     rgba(0,0,0,0) 17%
   );
   text-shadow: white 1px 0px 0px, white -1px 0px 0px;


### PR DESCRIPTION
When the viewport is decreased to the medium-sized view, link underlines disappear. Increasing one linear gradient percentage to 18 percent appears to fix the problem.
